### PR TITLE
added funcmap, better rust support

### DIFF
--- a/templates/readme.md
+++ b/templates/readme.md
@@ -1,12 +1,19 @@
 # Languages and Database Libraries
 
-To use a template, copy the respective file into your repo, set it in the `sqlc.yaml` and commit it along with the generated code. Don't hesitate to adjust it to your needs. Every project has different requirements. Commiting the template and the generated code allows to to see diffs once you change the template or add new queries.
+To use a template, copy the respective file into your repo, set it in the `sqlc.yaml` and commit it along with the generated code. Don't hesitate to adjust it to your needs. Every project has different requirements. Commiting the template and the generated code allows you to see diffs once you change the template or add new queries.
 
 If you come up with a template for a new language or database library, please contribute it, even if it is not perfect. It might be a good starting point for someone else.
 
 # Creating a new template from scratch
 
 Look at the [protobuf data structures provided by sqlc](https://github.com/sqlc-dev/sqlc/blob/main/protos/plugin/codegen.proto). They provide a list of queries and schemas. Imagine how you would turn them into your desired code. You probably want to loop over the queries and generate a return type and function for every query.
+
+Additionally, some functions are mapped into the template:
+ 
+- strings.ToLower is mapped to ToLower which allows for case-insensitive comparisons particularly for SQL types;
+- strings.Contains is mapped to Contains the Rust example uses this to alter options based on the filename being processed;
+- GetPluginOption allows you to obtain values under plugin: options: in the sqlc.yaml so you can have custom flags for your templates, it returns "" if no value is set;
+- Please see the rustqlite example to see these being used.
 
 It would look something like this:
 

--- a/templates/readme.md
+++ b/templates/readme.md
@@ -4,6 +4,9 @@ To use a template, copy the respective file into your repo, set it in the `sqlc.
 
 If you come up with a template for a new language or database library, please contribute it, even if it is not perfect. It might be a good starting point for someone else.
 
+A test project for the rustql version that could be used as a simple project template is available at [https://github.com/ReenigneCA/rust_sqlc_test](https://github.com/ReenigneCA/rust_sqlc_test)
+
+
 # Creating a new template from scratch
 
 Look at the [protobuf data structures provided by sqlc](https://github.com/sqlc-dev/sqlc/blob/main/protos/plugin/codegen.proto). They provide a list of queries and schemas. Imagine how you would turn them into your desired code. You probably want to loop over the queries and generate a return type and function for every query.

--- a/templates/rust_rusqlite.go.tmpl
+++ b/templates/rust_rusqlite.go.tmpl
@@ -5,19 +5,39 @@ https://github.com/rusqlite/rusqlite
 https://pkg.go.dev/text/template
 */ -}}
 
+
+{{- $CacheStatementsGlobal :=  "cache_statements" | GetPluginOption -}}
+
 {{- define "RustType" -}}
 {{- $rustType := .Type.Name -}}
-{{- if eq .Type.Name "integer"}}{{ $rustType = "i64" }}
-{{- else if eq .Type.Name "text"}}{{ $rustType = "String" }}
+{{- $TypeName :=   .Type.Name | ToLower  -}}
+{{- if eq $TypeName "integer"}}{{ $rustType = "i64" }}
+{{- else if eq $TypeName "text"}}{{ $rustType = "String" }}
+{{- else if eq $TypeName "blob"}}{{ $rustType = "Vec<u8>" }}
+{{- else if eq $TypeName "real"}}{{ $rustType = "f64" }}
+{{- else if eq $TypeName "float"}}{{ $rustType = "f64" }}
+{{- else if eq $TypeName "double"}}{{ $rustType = "f64" }}
+{{- else if eq $TypeName "boolean"}}{{ $rustType = "bool" }}
+{{- else if eq $TypeName "bool"}}{{ $rustType = "bool" }}
 {{- end -}}
 {{- $rustType }}
 {{- end -}}
 
-// This file is generated from queries.sql using queries_template.go.tmpl
-
+/* This file is generated from queries.sql using rust_rusqlite.go.tmpl
+  This template supports the following plugin options from sqlc.yaml
+    cache_statements: true/false # set whether to default to prepare_cached instead of prepare for
+    use_serde: true/false # set whether to import serde and annotate generated structs appropriately
+  This template will not generate a mod.rs file if the destination file is in a module you'll need to add one manually
+  .sql files containing queries can be used to override cache_statements option.
+    if nocache appears anywhere in the filename the queries in the file will all use prepare_cached
+    if cache appears, (but not nocache) anywhere in the filename the queries will all use prepare
+*/
 
 #[allow(unused)]
-use rusqlite::OptionalExtension;
+use rusqlite::{params,OptionalExtension};
+{{- if GetPluginOption "use_serde" }}
+use serde::{Serialize, Deserialize};
+{{- end -}}
 
 {{- range .Queries }}
 
@@ -26,7 +46,11 @@ use rusqlite::OptionalExtension;
 
 {{$rowType := printf "Row_%s" .Name -}}
 {{- if or (eq .Cmd ":many") (eq .Cmd ":one") }}
+    {{ if GetPluginOption "use_serde" -}}
+    #[derive(Serialize, Deserialize, Debug)]
+    {{- else -}}
     #[derive(Debug)]
+    {{- end }}
     #[allow(non_camel_case_types)]
     pub struct {{ $rowType }} { {{- range .Columns}}
     pub {{.Name}}:
@@ -37,23 +61,25 @@ use rusqlite::OptionalExtension;
 }
 
 {{end}}
-
-
-
-
-
+{{- $CacheStatements := $CacheStatementsGlobal -}}
+{{- if (Contains (ToLower .Filename) "cache") -}}
+  {{- $CacheStatements = true -}}
+{{- end -}}
+{{- if (Contains (ToLower .Filename) "nocache") -}}
+  {{- $CacheStatements = false -}}
+{{- end -}}
 
 {{- if eq .Cmd ":many" }}
 {{- $returnType := printf "Vec<%s>" $rowType -}}
-pub fn {{.Name}}({{range .Params}}
-  {{.Column.Name}}:{{template "RustType" .Column}},
+pub fn {{.Name}}(conn: &rusqlite::Connection{{range .Params}},
+  {{.Column.Name}}:{{template "RustType" .Column}}
 {{- end}}
- conn: &rusqlite::Connection
+
  ) -> Result<{{ $returnType }}, rusqlite::Error> {
 
-    let mut stmt = conn.prepare(r#"{{ .Text }}"#)?;
+    let mut stmt = {{- if $CacheStatements -}}conn.prepare_cached{{- else -}}conn.prepare{{- end -}}(r#"{{ .Text }}"#)?;
     let result : Result<{{ $returnType }}, rusqlite::Error> = stmt
-        .query_map([{{range .Params}} {{.Column.Name}}, {{end}}], |row| {
+        .query_map(params![{{range .Params}} {{.Column.Name}}, {{end}}], |row| {
             Ok({{$rowType}} { {{- range $index, $column := .Columns}}
               {{.Name}}: row.get({{$index}})?,
             {{- end}} })
@@ -67,15 +93,15 @@ pub fn {{.Name}}({{range .Params}}
 
 {{- if eq .Cmd ":one" }}
 {{- $returnType := printf "Option<%s>" $rowType -}}
-pub fn {{.Name}}({{range .Params}}
-  {{.Column.Name}}:{{template "RustType" .Column}},
+pub fn {{.Name}}(conn: &rusqlite::Connection{{range .Params}},
+  {{.Column.Name}}:{{template "RustType" .Column}}
 {{- end}}
- conn: &rusqlite::Connection
+
  ) -> Result<{{ $returnType }}, rusqlite::Error> {
 
-    let mut stmt = conn.prepare(r#"{{ .Text }}"#)?;
+    let mut stmt = {{- if $CacheStatements -}}conn.prepare_cached{{- else -}}conn.prepare{{- end -}}(r#"{{ .Text }}"#)?;
     let result : Result<{{ $returnType }}, rusqlite::Error> = stmt
-        .query_row([{{range .Params}} {{.Column.Name}}, {{end}}], |row| {
+        .query_row(params![{{range .Params}} {{.Column.Name}}, {{end}}], |row| {
             Ok({{$rowType}} { {{- range $index, $column := .Columns}}
               {{.Name}}: row.get({{$index}})?,
             {{- end}} })
@@ -86,10 +112,10 @@ pub fn {{.Name}}({{range .Params}}
 
 
 {{- if eq .Cmd ":exec" }}
-pub fn {{.Name}}({{range .Params}}
-  {{.Column.Name}}:{{template "RustType" .Column}},
+pub fn {{.Name}}(conn: &rusqlite::Connection{{range .Params}},
+  {{.Column.Name}}:{{template "RustType" .Column}}
 {{- end}}
- conn: &rusqlite::Connection
+
  ) -> Result<usize, rusqlite::Error> {
     conn.execute(r#"{{ .Text }}"#, ({{range .Params}} {{.Column.Name}}, {{end}}))
 }


### PR DESCRIPTION
I added some functions in a funcmap to make templates more powerful (see description in updated template readme.md) and configurable. ToLower is particularly important as SQL isn't case sensitive. I added logic to rename parameters that have duplicate names

```SQL
UPDATE users set username=? where username=?
```
The above query used to fail to produce rust code that would compile as both parameters would be named username. Now parameters with identical names are named param,param1,param2 etc. I don't think the protobuf plugin system gives the information needed to give better names users can use `@new_name` if they don't like the numbering.

for the rust template:

- type mappings are now case insensitive;
- added missing type mappings;
- changed the function signatures so the connection comes first not last;
- added an option to decide if generated code should use prepare or prepare_cached both globally and by .sql file;
- added an option to turn on serde serialisation support for generated structs;
- added use of params! macro so that queries that take parameters of mixed types don't fail to compile.

I updated the template readme to talk about the funcmap functions I added.

Overall I would say the rusqlite template is now in a late alpha or early beta state prior to this commit it only worked for pretty specific SQL.


